### PR TITLE
Include Bounds on Geocodin Response

### DIFF
--- a/geocoding.go
+++ b/geocoding.go
@@ -192,6 +192,7 @@ type AddressComponent struct {
 type AddressGeometry struct {
 	Location     LatLng       `json:"location"`
 	LocationType string       `json:"location_type"`
+	Bounds       LatLngBounds `json:"bounds"`
 	Viewport     LatLngBounds `json:"viewport"`
 	Types        []string     `json:"types"`
 }


### PR DESCRIPTION
As documented here:
https://developers.google.com/maps/documentation/geocoding/intro#GeocodingResponses

The Geometry may contain an attribute called bounds and this attribute
is not on AddressGeometry, This PR fixes it.